### PR TITLE
Potentially resolve lag by caching models.

### DIFF
--- a/src/main/java/com/svennieke/statues/renderer/PlayerStatueRenderer.java
+++ b/src/main/java/com/svennieke/statues/renderer/PlayerStatueRenderer.java
@@ -27,6 +27,7 @@ public class PlayerStatueRenderer extends TileEntitySpecialRenderer<PlayerStatue
     public static PlayerStatueRenderer instance;
 
     public static final ModelPlayer model = new ModelPlayer(0.03125F, false);
+    public static final ModelPlayer slimModel = new ModelPlayer(0.03125F, true);
 
     @Override
     public void setRendererDispatcher(TileEntityRendererDispatcher rendererDispatcherIn)
@@ -73,7 +74,7 @@ public class PlayerStatueRenderer extends TileEntitySpecialRenderer<PlayerStatue
                 }
 
                 if (SkinUtil.isSlimSkin(profile.getId())) {
-                    theModel = new ModelPlayer(0.03125F, true);
+                    theModel = this.slimModel;
                 }
             }
 


### PR DESCRIPTION
Creating a new instance every tick is a recipe for lag.

Quoting tterrag:

"100% native leak, ModelBase has no way to cleanup its buffers, if you create one, you allocate a displaylist"

(Please note this isn't 100% tested... or tested at all. But if it doesn't work it should just be a stupid typo on my part.)